### PR TITLE
Add command whitelist and safety checks for custom bindings

### DIFF
--- a/app/Input/CommandSanitizer.cs
+++ b/app/Input/CommandSanitizer.cs
@@ -1,0 +1,14 @@
+using System.Text.RegularExpressions;
+
+namespace GHelper.Input;
+
+public static class CommandSanitizer
+{
+    private static readonly Regex AllowedCommandPattern = new(@"^[\w\s\.\-:/\\]+$");
+
+    public static bool IsCommandAllowed(string command)
+    {
+        if (string.IsNullOrWhiteSpace(command)) return false;
+        return AllowedCommandPattern.IsMatch(command) && command.IndexOfAny(new[] { '&', '|', '>', '<', ';' }) == -1;
+    }
+}

--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -6,6 +6,7 @@ using Microsoft.Win32;
 using System.Diagnostics;
 using System.Management;
 using System.Text.RegularExpressions;
+using System.Windows.Forms;
 
 namespace GHelper.Input
 {
@@ -228,6 +229,11 @@ namespace GHelper.Input
             return hexValues;
         }
 
+        static bool ConfirmUnsafeCommand(string command)
+        {
+            DialogResult result = MessageBox.Show($"Run command?\n{command}", "Custom command", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+            return result == DialogResult.Yes;
+        }
 
         static void CustomKey(string configKey = "m3")
         {
@@ -1208,6 +1214,9 @@ namespace GHelper.Input
         static void LaunchProcess(string command = "")
         {
             if (string.IsNullOrEmpty(command)) return;
+
+            if (!CommandSanitizer.IsCommandAllowed(command) && !ConfirmUnsafeCommand(command)) return;
+
             try
             {
                 if (command.StartsWith("shutdown"))

--- a/docs/README.md
+++ b/docs/README.md
@@ -152,6 +152,11 @@ Huge thanks to [@IceStormNG](https://github.com/IceStormNG) 👑 for contributio
 - ``Ctrl + Shift + Alt + F20`` - Custom 2 (if exists)
 - [Custom keybindings / hotkeys](https://github.com/seerge/g-helper/wiki/Power-user-settings#custom-hotkey-actions)
 
+> [!NOTE]
+> **Custom command whitelist**
+> 
+> For safety, custom hotkey commands are limited to simple command lines made up of letters, numbers, spaces and `-_.:/\\` characters. Shell operators like `&`, `|`, `;`, `<` or `>` are blocked and will prompt for confirmation before execution.
+
 ### 🎮ROG Ally Bindings
 - ``M + DPad Left / Right`` - Display Brightness
 - ``M + DPad Up`` - Touch keyboard

--- a/tests/CommandWhitelistTests.cs
+++ b/tests/CommandWhitelistTests.cs
@@ -1,0 +1,19 @@
+using GHelper.Input;
+using Xunit;
+
+namespace GHelper.Tests;
+
+public class CommandWhitelistTests
+{
+    [Fact]
+    public void AllowsSimpleCommand()
+    {
+        Assert.True(CommandSanitizer.IsCommandAllowed("calc"));
+    }
+
+    [Fact]
+    public void RejectsPipedCommand()
+    {
+        Assert.False(CommandSanitizer.IsCommandAllowed("calc && rm -rf /"));
+    }
+}

--- a/tests/GHelper.Tests.csproj
+++ b/tests/GHelper.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../app/Input/CommandSanitizer.cs" Link="CommandSanitizer.cs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- whitelist custom commands with `CommandSanitizer`
- prompt before running unsafe custom commands
- document allowed command patterns
- add tests for command whitelist

## Testing
- `dotnet build app/GHelper.csproj -p:EnableWindowsTargeting=true`
- `dotnet test tests/GHelper.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b29eb4de6083209f248097a2b15528