### PR TITLE
Verify plugin zip before extraction

### DIFF
--- a/app/Ryzen/RyzenControl.cs
+++ b/app/Ryzen/RyzenControl.cs
@@ -7,6 +7,8 @@
 using GHelper.Helpers;
 using System.Management;
 using System.Net;
+using System.Windows.Forms;
+using GHelper.Security;
 
 namespace Ryzen
 {
@@ -202,6 +204,14 @@ namespace Ryzen
                     Logger.WriteLine(ex.Message);
                     Logger.WriteLine(ex.ToString());
                     if (!ProcessHelper.IsUserAdministrator() && !ex.Message.Contains("remote server")) ProcessHelper.RunAsAdmin("uv");
+                    return;
+                }
+
+                if (!PluginVerifier.Verify(zipLocation))
+                {
+                    Logger.WriteLine("Plugin ZIP verification failed");
+                    MessageBox.Show("Downloaded plugin failed verification and will not be installed.", "Security warning");
+                    try { File.Delete(zipLocation); } catch { }
                     return;
                 }
 

--- a/app/Security/PluginVerifier.cs
+++ b/app/Security/PluginVerifier.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+
+namespace GHelper.Security
+{
+    internal static class PluginVerifier
+    {
+        // SHA256 hash of the official PluginAdvancedSettings.zip
+        internal const string PluginAdvancedSettingsHash = "b4a85e23e06c9c4d80cf538398015c89c8fb04453ed23784d7efe592dd4876f5";
+
+        internal static bool Verify(string filePath)
+        {
+            try
+            {
+                using var sha = SHA256.Create();
+                using var stream = File.OpenRead(filePath);
+                var hash = Convert.ToHexString(sha.ComputeHash(stream)).ToLowerInvariant();
+                return hash == PluginAdvancedSettingsHash;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/tests/PluginVerificationTests/GlobalUsings.cs
+++ b/tests/PluginVerificationTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/PluginVerificationTests/PluginVerificationTests.csproj
+++ b/tests/PluginVerificationTests/PluginVerificationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../app/Security/PluginVerifier.cs" Link="PluginVerifier.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PluginVerificationTests/PluginVerifierTests.cs
+++ b/tests/PluginVerificationTests/PluginVerifierTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using GHelper.Security;
+using Xunit;
+
+namespace PluginVerificationTests;
+
+public class PluginVerifierTests
+{
+    [Fact]
+    public void ModifiedZip_IsRejected()
+    {
+        string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(tempDir);
+        File.WriteAllText(Path.Combine(tempDir, "test.txt"), "malicious");
+        string tempZip = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".zip");
+        ZipFile.CreateFromDirectory(tempDir, tempZip);
+
+        try
+        {
+            Assert.False(PluginVerifier.Verify(tempZip));
+        }
+        finally
+        {
+            File.Delete(tempZip);
+            Directory.Delete(tempDir, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- verify PluginAdvancedSettings.zip against known SHA256 before unpacking
- add PluginVerifier with trusted hash
- add test ensuring modified ZIPs are rejected

## Testing
- `dotnet test tests/PluginVerificationTests/PluginVerificationTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b29eb3ff408320b448c8392ccf9bd9