### PR TITLE
Fix test project configuration to avoid compiling unrelated tests

### DIFF
--- a/tests/GHelper.Tests.csproj
+++ b/tests/GHelper.Tests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="CommandWhitelistTests.cs" />
     <Compile Include="../app/Input/CommandSanitizer.cs" Link="CommandSanitizer.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- prevent unrelated sub-test directories from being compiled by `GHelper.Tests`
- explicitly include `CommandWhitelistTests` and `CommandSanitizer` in test project

## Testing
- `dotnet test tests/GHelper.Tests.csproj`
- `dotnet test tests/OpenLibSys.Tests/OpenLibSys.Tests.csproj`
- `dotnet test tests/PluginVerificationTests/PluginVerificationTests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b2b6bd092c8320a7b1fcb9568ba5ee